### PR TITLE
Force string-typed keys

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -196,7 +196,7 @@ type decoder struct {
 var (
 	mapItemType    = reflect.TypeOf(MapItem{})
 	durationType   = reflect.TypeOf(time.Duration(0))
-	defaultMapType = reflect.TypeOf(map[interface{}]interface{}{})
+	defaultMapType = reflect.TypeOf(map[string]interface{}{})
 	ifaceType      = defaultMapType.Elem()
 )
 


### PR DESCRIPTION
When unmarshaling objects to map[string]interface{}, map values will be
of the type map[interface{}]interface{}. This is problematic when
attempting to marshal the object out to JSON, since encoding/json only
supports string keys.

This change is a patch to cause all child maps to have string-typed
keys.